### PR TITLE
Fix exception logging

### DIFF
--- a/lib/jsonLogger.js
+++ b/lib/jsonLogger.js
@@ -3,19 +3,47 @@ const logger = require('pino')({ name: 'next.js' })
 const getLogMethod = level => {
   switch (level) {
     case 'error':
-      return logger.error.bind(logger, { prefix: level })
+      return logger.error.bind(logger)
     case 'warn':
-      return logger.warn.bind(logger, { prefix: level })
+      return logger.warn.bind(logger)
     default:
-      return logger.info.bind(logger, { prefix: level })
+      return logger.info.bind(logger)
   }
+}
+
+const isError = obj => Object.prototype.toString.call(obj) === '[object Error]'
+
+const getMessage = obj => {
+  if (isError(obj)) {
+    return obj.stack
+  }
+  if (obj.length === 1) {
+    return obj[0]
+  }
+  return obj
+}
+
+const getMergingObject = (level, obj) => {
+  if (isError(obj)) {
+    const errorProps = Object.getOwnPropertyNames(obj).reduce(
+      (props, prop) => ({
+        ...props,
+        [prop]: obj[prop],
+      }),
+      {}
+    )
+    return { prefix: level, ...errorProps }
+  }
+  return { prefix: level }
 }
 
 module.exports = prefix => {
   const logMethod = getLogMethod(prefix)
 
-  return (...args) => {
-    const message = args.length === 1 ? args[0] : args
-    logMethod(message)
-  }
+  return (level => obj => {
+    const message = getMessage(obj)
+    const mergingObject = getMergingObject(level, obj)
+
+    return logMethod(mergingObject, message)
+  })(prefix)
 }

--- a/lib/jsonLogger.js
+++ b/lib/jsonLogger.js
@@ -40,10 +40,10 @@ const getMergingObject = (level, obj) => {
 module.exports = prefix => {
   const logMethod = getLogMethod(prefix)
 
-  return (level => obj => {
+  return obj => {
     const message = getMessage(obj)
-    const mergingObject = getMergingObject(level, obj)
+    const mergingObject = getMergingObject(prefix, obj)
 
     return logMethod(mergingObject, message)
-  })(prefix)
+  }
 }

--- a/tests/scenarios.js
+++ b/tests/scenarios.js
@@ -6,6 +6,22 @@ const buildConsoleScript = (method, payload) => `
 console.${method}(${payload})
 `
 
+const buildCustomErrorScript = name => `
+class ${name} extends Error {
+  constructor(...params) {
+    super(...params)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, CustomError)
+    }
+
+    this.name = '${name}'
+  }
+}
+
+console.error(new ${name}('Message for ${name}'))
+`
+
 const nextScenarios = [
   // Next.js logger - basic messages
   [
@@ -132,6 +148,25 @@ const consoleScenarios = [
   ],
 ]
 
-module.exports = [...nextScenarios, ...consoleScenarios]
+const exceptionScenarios = [
+  [
+    'exception - error',
+    buildConsoleScript('error', "new Error('Message for error')"),
+    { level: 50, name: 'next.js', msg: expect.stringMatching(/^Error: Message for error\n/), prefix: 'error' },
+  ],
+  [
+    'exception - custom error',
+    buildCustomErrorScript('CustomError'),
+    {
+      level: 50,
+      name: 'CustomError',
+      msg: expect.stringMatching(/^CustomError: Message for CustomError\n/),
+      prefix: 'error',
+    },
+  ],
+]
+
+module.exports = [...nextScenarios, ...consoleScenarios, ...exceptionScenarios]
 module.exports.next = nextScenarios
 module.exports.console = consoleScenarios
+module.exports.exceptions = exceptionScenarios


### PR DESCRIPTION
Properly log `Error` object and its properties, fixes #3. 

Went with `stack` as an error message for `Error` objects as it works nicely with [pino-pretty](https://github.com/pinojs/pino-pretty)


Example output:
```sh
$ npm start

> next-logger-example@0.1.0 start
> NODE_OPTIONS='-r next-logger' next start

{"level":30,"time":1626264458782,"pid":18407,"hostname":"MacBook-Pro","name":"next.js","prefix":"ready","msg":"started server on 0.0.0.0:3000, url: http://localhost:3000"}
{"level":50,"time":1626264459086,"pid":18407,"hostname":"MacBook-Pro","name":"next.js","prefix":"error","stack":"Error: Could not find a production build in the '/path/to/next-logger-example/.next' directory. Try building your app with 'next build' before starting the production server. https://nextjs.org/docs/messages/production-start-no-build-id\n    at Server.readBuildId (/path/to/next-logger-example/node_modules/next/dist/next-server/server/next-server.js:151:355)\n    at new Server (/path/to/next-logger-example/node_modules/next/dist/next-server/server/next-server.js:3:120)\n    at NextServer.createServer (/path/to/next-logger-example/node_modules/next/dist/server/next.js:1:2935)\n    at async /path/to/next-logger-example/node_modules/next/dist/server/next.js:1:3360","message":"Could not find a production build in the '/path/to/next-logger-example/.next' directory. Try building your app with 'next build' before starting the production server. https://nextjs.org/docs/messages/production-start-no-build-id","msg":"Error: Could not find a production build in the '/path/to/next-logger-example/.next' directory. Try building your app with 'next build' before starting the production server. https://nextjs.org/docs/messages/production-start-no-build-id\n    at Server.readBuildId (/path/to/next-logger-example/node_modules/next/dist/next-server/server/next-server.js:151:355)\n    at new Server (/path/to/next-logger-example/node_modules/next/dist/next-server/server/next-server.js:3:120)\n    at NextServer.createServer (/path/to/next-logger-example/node_modules/next/dist/server/next.js:1:2935)\n    at async /path/to/next-logger-example/node_modules/next/dist/server/next.js:1:3360"}
```

Throwing error inside Next.js application also works:
```sh
$ npm run dev

> next-logger-example@0.1.0 dev
> NODE_OPTIONS='-r next-logger' next dev | pino-pretty

[1626264485580] INFO (next.js/18432 on MacBook-Pro): started server on 0.0.0.0:3000, url: http://localhost:3000
    prefix: "ready"
[1626264485713] INFO (next.js/18432 on MacBook-Pro): Using webpack 5. Reason: Enabled by default https://nextjs.org/docs/messages/webpack5
    prefix: "info"
[1626264487760] INFO (next.js/18432 on MacBook-Pro): compiled successfully
    prefix: "event"
[1626264489621] INFO (next.js/18432 on MacBook-Pro): build page: /next/dist/pages/_error
    prefix: "event"
[1626264489622] INFO (next.js/18432 on MacBook-Pro): compiling...
    prefix: "wait"
[1626264489764] INFO (next.js/18432 on MacBook-Pro): compiled successfully
    prefix: "event"
[1626264515043] INFO (next.js/18432 on MacBook-Pro): build page: /
    prefix: "event"
[1626264515043] INFO (next.js/18432 on MacBook-Pro): compiling...
    prefix: "wait"
[1626264517795] INFO (next.js/18432 on MacBook-Pro): compiled successfully
    prefix: "event"
[1626264517902] ERROR (next.js/18432 on MacBook-Pro): Error: Phail
    at Home (webpack-internal:///./pages/index.js:19:9)
    at processChild (/path/to/next-logger-example/node_modules/react-dom/cjs/react-dom-server.node.development.js:3353:14)
    at resolve (/path/to/next-logger-example/node_modules/react-dom/cjs/react-dom-server.node.development.js:3270:5)
    at ReactDOMServerRenderer.render (/path/to/next-logger-example/node_modules/react-dom/cjs/react-dom-server.node.development.js:3753:22)
    at ReactDOMServerRenderer.read (/path/to/next-logger-example/node_modules/react-dom/cjs/react-dom-server.node.development.js:3690:29)
    at renderToString (/path/to/next-logger-example/node_modules/react-dom/cjs/react-dom-server.node.development.js:4298:27)
    at Object.renderPage (/path/to/next-logger-example/node_modules/next/dist/next-server/server/render.js:53:854)
    at Function.getInitialProps (webpack-internal:///./node_modules/next/dist/pages/_document.js:211:19)
    at loadGetInitialProps (/path/to/next-logger-example/node_modules/next/dist/next-server/lib/utils.js:5:101)
    at renderToHTML (/path/to/next-logger-example/node_modules/next/dist/next-server/server/render.js:53:1145)
    prefix: "error"
    stack: "Error: Phail\n    at Home (webpack-internal:///./pages/index.js:19:9)\n    at processChild (/path/to/next-logger-example/node_modules/react-dom/cjs/react-dom-server.node.development.js:3353:14)\n    at resolve (/path/to/next-logger-example/node_modules/react-dom/cjs/react-dom-server.node.development.js:3270:5)\n    at ReactDOMServerRenderer.render (/path/to/next-logger-example/node_modules/react-dom/cjs/react-dom-server.node.development.js:3753:22)\n    at ReactDOMServerRenderer.read (/path/to/next-logger-example/node_modules/react-dom/cjs/react-dom-server.node.development.js:3690:29)\n    at renderToString (/path/to/next-logger-example/node_modules/react-dom/cjs/react-dom-server.node.development.js:4298:27)\n    at Object.renderPage (/path/to/next-logger-example/node_modules/next/dist/next-server/server/render.js:53:854)\n    at Function.getInitialProps (webpack-internal:///./node_modules/next/dist/pages/_document.js:211:19)\n    at loadGetInitialProps (/path/to/next-logger-example/node_modules/next/dist/next-server/lib/utils.js:5:101)\n    at renderToHTML (/path/to/next-logger-example/node_modules/next/dist/next-server/server/render.js:53:1145)"
```