### PR TITLE
Handle undefined and null values

### DIFF
--- a/lib/jsonLogger.js
+++ b/lib/jsonLogger.js
@@ -14,8 +14,8 @@ const getLogMethod = level => {
 const isError = obj => Object.prototype.toString.call(obj) === '[object Error]'
 
 const getMessage = obj => {
-  if (obj == null) {
-    return obj;
+  if (obj === null || obj === undefined) {
+    return obj
   }
   if (isError(obj)) {
     return obj.stack

--- a/lib/jsonLogger.js
+++ b/lib/jsonLogger.js
@@ -14,6 +14,9 @@ const getLogMethod = level => {
 const isError = obj => Object.prototype.toString.call(obj) === '[object Error]'
 
 const getMessage = obj => {
+  if (obj == null) {
+    return obj;
+  }
   if (isError(obj)) {
     return obj.stack
   }

--- a/tests/scenarios.js
+++ b/tests/scenarios.js
@@ -143,12 +143,12 @@ const consoleScenarios = [
   [
     'console.log - undefined',
     buildConsoleScript('log', undefined),
-    { level: 50, name: 'next.js', prefix: 'error' },
+    { level: 30, name: 'next.js', prefix: 'log' },
   ],
   [
     'console.log - null',
     buildConsoleScript('log', null),
-    { level: 50, name: 'next.js', msg: null, prefix: 'error' },
+    { level: 30, name: 'next.js', msg: null, prefix: 'log' },
   ],
   // Sanity checks for Pino to make sure `console.*` isn't broken
   [

--- a/tests/scenarios.js
+++ b/tests/scenarios.js
@@ -140,16 +140,8 @@ const consoleScenarios = [
     buildConsoleScript('error', "{ foo: 'Message for error' }"),
     { level: 50, name: 'next.js', msg: { foo: 'Message for error' }, prefix: 'error' },
   ],
-  [
-    'console.log - undefined',
-    buildConsoleScript('log', undefined),
-    { level: 30, name: 'next.js', prefix: 'log' },
-  ],
-  [
-    'console.log - null',
-    buildConsoleScript('log', null),
-    { level: 30, name: 'next.js', msg: null, prefix: 'log' },
-  ],
+  ['console.log - undefined', buildConsoleScript('log', undefined), { level: 30, name: 'next.js', prefix: 'log' }],
+  ['console.log - null', buildConsoleScript('log', null), { level: 30, name: 'next.js', msg: null, prefix: 'log' }],
   // Sanity checks for Pino to make sure `console.*` isn't broken
   [
     'pino - sanity check',

--- a/tests/scenarios.js
+++ b/tests/scenarios.js
@@ -140,6 +140,16 @@ const consoleScenarios = [
     buildConsoleScript('error', "{ foo: 'Message for error' }"),
     { level: 50, name: 'next.js', msg: { foo: 'Message for error' }, prefix: 'error' },
   ],
+  [
+    'console.log - undefined',
+    buildConsoleScript('log', undefined),
+    { level: 50, name: 'next.js', prefix: 'error' },
+  ],
+  [
+    'console.log - null',
+    buildConsoleScript('log', null),
+    { level: 50, name: 'next.js', msg: null, prefix: 'error' },
+  ],
   // Sanity checks for Pino to make sure `console.*` isn't broken
   [
     'pino - sanity check',


### PR DESCRIPTION
Hello,

I noticed that if the log is either `null` or `undefined`, the `obj.length === 1` check fails :) 

Not sure if this is the desired place to check for that? I would also be reasonable to check for that before calling `getMessage`.